### PR TITLE
Increase timeline h1 lineheight to avoid character overflow

### DIFF
--- a/components/Timetable.vue
+++ b/components/Timetable.vue
@@ -243,7 +243,7 @@ export default class extends Vue {
   margin-top: 5px;
   font-size: 1em;
   font-weight: normal;
-  line-height: 1.2em;
+  line-height: 1.4em;
   text-overflow: ellipsis;
   overflow: hidden;
 }


### PR DESCRIPTION
Before:

<img width="187" alt="2018-08-06 12 17 25" src="https://user-images.githubusercontent.com/16474/43696883-c3edbf48-9972-11e8-8409-b42a34855e2f.png">

The `g` is overflow so increase line-height to avoid.